### PR TITLE
Fix force reindex and correct index counts

### DIFF
--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -28,6 +28,11 @@ export async function handleIndexWorkspace(
   try {
     console.error(`[index_workspace] Starting workspace indexing (force=${force})...`);
 
+    if (force) {
+      console.error('[index_workspace] Force enabled: clearing existing index state first...');
+      await serviceClient.clearIndex();
+    }
+
     if (background) {
       // Fire and forget background worker
       serviceClient.indexWorkspaceInBackground().catch((error) => {

--- a/src/worker/IndexWorker.ts
+++ b/src/worker/IndexWorker.ts
@@ -32,6 +32,8 @@ export async function runIndexJob(
      count: result.indexed,
      skipped: result.skipped,
      errors: result.errors,
+     totalIndexable: result.totalIndexable,
+     unchangedSkipped: result.unchangedSkipped,
    });
  } catch (error) {
    send({

--- a/src/worker/messages.ts
+++ b/src/worker/messages.ts
@@ -1,7 +1,15 @@
 export type WorkerMessage =
   | { type: 'index_start'; files: string[] }
   | { type: 'index_progress'; current: number; total: number }
-  | { type: 'index_complete'; duration: number; count: number; skipped?: number; errors?: string[] }
+  | {
+      type: 'index_complete';
+      duration: number;
+      count: number;
+      skipped?: number;
+      errors?: string[];
+      totalIndexable?: number;
+      unchangedSkipped?: number;
+    }
   | { type: 'index_error'; error: string };
 
 export interface WorkerPayload {


### PR DESCRIPTION
Fixes two indexing regressions:
- `index_workspace` now honors `force` by clearing `.augment-context-state.json` / `.augment-index-state.json` first.
- `indexWorkspace()` no longer reports misleading low `fileCount` when skipping unchanged files, and treats all-unchanged runs as successful no-ops.

Also threads `totalIndexable`/`unchangedSkipped` through the worker path and adds unit tests.

Tests: `npm test`, `npm run build`.