### PR TITLE
Persist plans and support plan_id execution

### DIFF
--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -44,7 +44,7 @@ export async function handleIndexWorkspace(
       }, null, 2);
     }
 
-    await serviceClient.indexWorkspace();
+    const result = await serviceClient.indexWorkspace();
     
     const elapsed = Date.now() - startTime;
     
@@ -52,6 +52,11 @@ export async function handleIndexWorkspace(
       success: true,
       message: `Workspace indexed successfully in ${elapsed}ms`,
       elapsed_ms: elapsed,
+      indexed: result.indexed,
+      skipped: result.skipped,
+      total_indexable: result.totalIndexable,
+      unchanged_skipped: result.unchangedSkipped,
+      errors: result.errors,
     }, null, 2);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary\n- Auto-save plans created by create_plan and surface persistence status in output.\n- Allow execute_plan to load persisted plans by plan_id (or fallback to plan_id when JSON is invalid).\n- Expand index_workspace output with indexed/total/skipped counts for clearer visibility.\n- Update tool schemas and add tests for plan_id execution.\n\n## Testing\n- npm run build\n- npm test