### PR TITLE
chore: prepare v1.9.1 release

### DIFF
--- a/config/ci/compatibility-rollback-envelope.json
+++ b/config/ci/compatibility-rollback-envelope.json
@@ -155,7 +155,7 @@
   },
   "node_and_package_matrix": {
     "package_json_path": "package.json",
-    "package_json_version": "1.9.0",
+    "package_json_version": "1.9.1",
     "package_engines_declared": true,
     "package_engines": { "node": ">=18" },
     "ci_node_matrix_source": ".github/workflows/test.yml",

--- a/config/ci/distribution-policy.json
+++ b/config/ci/distribution-policy.json
@@ -3,7 +3,7 @@
   "decision": "supported",
   "owner_lane": "Release engineering / F8",
   "package_name": "context-engine-mcp-server",
-  "package_version": "1.9.0",
+  "package_version": "1.9.1",
   "closure_task": "P1a",
   "rejected_task": "P1b",
   "node_matrix": ["18.x", "20.x", "22.x"],

--- a/config/ci/docs-version-reconciliation.json
+++ b/config/ci/docs-version-reconciliation.json
@@ -3,10 +3,10 @@
   "task_id": "D1a",
   "title": "Generated docs and version reconciliation",
   "owner_lane": "Governance / F0",
-  "depends_on_note": "Full post-T1d2 re-verification remains required after transport migration; this contract freezes current 52-tool / 1.9.0 alignment now.",
+  "depends_on_note": "Full post-T1d2 re-verification remains required after transport migration; this contract freezes current 52-tool / 1.9.1 alignment now.",
   "depends_on": ["R6"],
   "expected": {
-    "package_version": "1.9.0",
+    "package_version": "1.9.1",
     "mcp_server_version_export": "MCP_SERVER_VERSION",
     "mcp_tool_count": 52,
     "rest_mapping_count": 20,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-engine-mcp-server",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-engine-mcp-server",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-engine-mcp-server",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "MCP server implementation for local context engine workflows with openai-session runtime, planning, and execution features",
   "type": "module",
   "main": "dist/index.js",

--- a/src/mcp/tools/manifest.ts
+++ b/src/mcp/tools/manifest.ts
@@ -16,7 +16,7 @@ export interface ToolManifestArgs {
   // No arguments
 }
 
-export const MCP_SERVER_VERSION = '1.9.0';
+export const MCP_SERVER_VERSION = '1.9.1';
 
 export const toolManifest = {
   version: MCP_SERVER_VERSION,

--- a/src/reviewer/pipeline/synthesis.ts
+++ b/src/reviewer/pipeline/synthesis.ts
@@ -8,7 +8,7 @@ import type { EnterpriseFinding, EnterpriseReviewResult } from '../types.js';
 import type { ReviewAnalyzerResults, ReviewDiffStaticAnalysisMetadata } from './analyzerOrchestrator.js';
 import type { ReviewDiffInput } from '../reviewDiff.js';
 
-const TOOL_VERSION = '1.9.0';
+const TOOL_VERSION = '1.9.1';
 
 export type ReviewDiffResultWithStaticMetadata = EnterpriseReviewResult & {
   static_analysis?: ReviewDiffStaticAnalysisMetadata;

--- a/src/reviewer/reviewDiff.ts
+++ b/src/reviewer/reviewDiff.ts
@@ -5,7 +5,7 @@ import { runReviewAnalyzers } from './pipeline/analyzerOrchestrator.js';
 import { buildDeterministicFindings, buildReviewDiffResult } from './pipeline/synthesis.js';
 import type { EnterpriseReviewResult } from './types.js';
 
-export const TOOL_VERSION = '1.9.0';
+export const TOOL_VERSION = '1.9.1';
 
 export interface ReviewDiffOptions {
   confidence_threshold?: number;

--- a/tests/ci/__snapshots__/reviewDiffArtifacts.test.ts.snap
+++ b/tests/ci/__snapshots__/reviewDiffArtifacts.test.ts.snap
@@ -24,7 +24,7 @@ exports[`CI artifacts: scripts/ci/review-diff.ts (deterministic, LLM-off) produc
       "tool": {
         "driver": {
           "name": "context-engine-review",
-          "version": "1.9.0",
+          "version": "1.9.1",
           "rules": [
             {
               "id": "PRE001",
@@ -173,7 +173,7 @@ exports[`CI artifacts: scripts/ci/review-diff.ts (deterministic, LLM-off) produc
     "llm_findings_added": 0
   },
   "metadata": {
-    "tool_version": "1.9.0",
+    "tool_version": "1.9.1",
     "warnings": []
   },
   "sarif": {
@@ -184,7 +184,7 @@ exports[`CI artifacts: scripts/ci/review-diff.ts (deterministic, LLM-off) produc
         "tool": {
           "driver": {
             "name": "context-engine-review",
-            "version": "1.9.0",
+            "version": "1.9.1",
             "rules": [
               {
                 "id": "PRE001",
@@ -304,7 +304,7 @@ exports[`CI artifacts: scripts/ci/review-diff.ts (deterministic, LLM-off) produc
       "tool": {
         "driver": {
           "name": "context-engine-review",
-          "version": "1.9.0",
+          "version": "1.9.1",
           "rules": [
             {
               "id": "PRE001",
@@ -453,7 +453,7 @@ exports[`CI artifacts: scripts/ci/review-diff.ts (deterministic, LLM-off) produc
     "llm_findings_added": 0
   },
   "metadata": {
-    "tool_version": "1.9.0",
+    "tool_version": "1.9.1",
     "warnings": []
   },
   "sarif": {
@@ -464,7 +464,7 @@ exports[`CI artifacts: scripts/ci/review-diff.ts (deterministic, LLM-off) produc
         "tool": {
           "driver": {
             "name": "context-engine-review",
-            "version": "1.9.0",
+            "version": "1.9.1",
             "rules": [
               {
                 "id": "PRE001",
@@ -588,7 +588,7 @@ exports[`CI artifacts: scripts/ci/review-diff.ts (deterministic, LLM-off) produc
       "tool": {
         "driver": {
           "name": "context-engine-review",
-          "version": "1.9.0",
+          "version": "1.9.1",
           "rules": [
             {
               "id": "SEC001",
@@ -739,7 +739,7 @@ exports[`CI artifacts: scripts/ci/review-diff.ts (deterministic, LLM-off) produc
     "llm_findings_added": 0
   },
   "metadata": {
-    "tool_version": "1.9.0",
+    "tool_version": "1.9.1",
     "warnings": []
   },
   "sarif": {
@@ -750,7 +750,7 @@ exports[`CI artifacts: scripts/ci/review-diff.ts (deterministic, LLM-off) produc
         "tool": {
           "driver": {
             "name": "context-engine-review",
-            "version": "1.9.0",
+            "version": "1.9.1",
             "rules": [
               {
                 "id": "SEC001",

--- a/tests/ci/closeoutContracts.test.ts
+++ b/tests/ci/closeoutContracts.test.ts
@@ -55,7 +55,7 @@ describe('D1b memory governance verification', () => {
 });
 
 describe('D1a docs/version reconciliation contract', () => {
-  it('pins expected 52-tool / 1.9.0 contract fields', () => {
+  it('pins expected 52-tool / 1.9.1 contract fields', () => {
     const contract = JSON.parse(
       fs.readFileSync(path.join(REPO_ROOT, 'config/ci/docs-version-reconciliation.json'), 'utf8')
     ) as {
@@ -66,7 +66,7 @@ describe('D1a docs/version reconciliation contract', () => {
         output_schema_covered_tool_count: number;
       };
     };
-    expect(contract.expected.package_version).toBe('1.9.0');
+    expect(contract.expected.package_version).toBe('1.9.1');
     expect(contract.expected.mcp_tool_count).toBe(52);
     expect(contract.expected.rest_mapping_count).toBe(20);
     expect(contract.expected.output_schema_covered_tool_count).toBe(14);

--- a/tests/snapshots/phase2/baseline/tool_manifest_basic.baseline.txt
+++ b/tests/snapshots/phase2/baseline/tool_manifest_basic.baseline.txt
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.0",
+  "version": "1.9.1",
   "capabilities": [
     "semantic_search",
     "symbol_navigation",

--- a/tests/tools/__snapshots__/reviewAuto.test.ts.snap
+++ b/tests/tools/__snapshots__/reviewAuto.test.ts.snap
@@ -44,7 +44,7 @@ exports[`review_auto tool selects review_diff when diff is provided 1`] = `
     "hotspots": [],
     "metadata": {
       "reviewed_at": "<fixed>",
-      "tool_version": "1.9.0",
+      "tool_version": "1.9.1",
       "warnings": [],
     },
     "risk_score": 4,
@@ -137,4 +137,3 @@ exports[`review_auto tool selects review_git_diff when no diff is provided 1`] =
   "selected_tool": "review_git_diff",
 }
 `;
-


### PR DESCRIPTION
## Summary
- prepare the coordinated v1.9.1 patch release
- align package, lockfile, MCP manifest, reviewer tool, and CI version contracts
- preserve the historical local v1.9.0 tag and all unrelated dirty artifacts

## Local verification
- npm run build
- npm run ci:check:docs-version-reconciliation
- node --import tsx scripts/ci/check-version-literals.ts
- npm run ci:check:supported-distribution-pack-proof
- compatibilityRollbackEnvelope.test.ts
- git diff --check

Q3d/T1*/A*/M1-M3 remain governed by the existing CONDITIONAL_GO release posture and are not claimed as completed by this patch.